### PR TITLE
Fix Python listener CPU usage

### DIFF
--- a/Raspberry pi code.py
+++ b/Raspberry pi code.py
@@ -17,6 +17,8 @@ def interrupt_listener():
         if ser.in_waiting > 0:
             line = ser.readline().decode('utf-8').rstrip()
             print(f"Message from Arduino: {line}")  # Display message immediately
+        # Prevent the thread from using 100% CPU when no data is available
+        time.sleep(0.1)
 
 
 def motor_control():


### PR DESCRIPTION
## Summary
- avoid busy loop in Raspberry Pi interrupt listener

## Testing
- `python3 -m py_compile 'Raspberry pi code.py'`

------
https://chatgpt.com/codex/tasks/task_e_683f5eee377883249fcd415e895003fa